### PR TITLE
Add hostname to parameter-dimension maps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Add hostname as a supported Google Analytics dimension
+
 ## [1.1.2] - 2018-10-05
-## Fixed
+### Fixed
 * Config sourced values of private key also need to be buffered with base64 decoding
 
 ## [1.1.1] - 2018-10-05

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The `:dimension` parameter indicates the requested dimension(s) for slicing the 
 |`eventCategory`| Slice data by eventCategory |
 |`eventAction`| Slice data by eventAction |
 |`eventLabel`| Slice data by eventAction |
+|`hostname`| Slice data by hostname |
 |other dimensions| Additional dimensions set in the the config file |
 |`none`| Don't slice data by any dimensions. Concatenated dimesions will override. |
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "config": "^1.25.1",
     "dotenv": "^6.0.0",
     "flora-sql-parser": "^0.7.10",
+    "gh-release": "^3.3.3",
     "googleapis": "^32.0.0",
     "joi": "^13.4.0",
     "koop": "^3.9.0",
@@ -36,10 +37,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ArcGIS/koop-provider-metrics.git"
+    "url": "git+https://github.com/koopjs/koop-provider-google-analytics.git"
   },
   "bugs": {
-    "url": "https://github.com/ArcGIS/koop-provider-metrics/issues"
+    "url": "https://github.com/koopjs/koop-provider-google-analytics/issues"
   },
   "homepage": "https://github.com/koopjs/koop-provider-google-analytics",
   "keywords": [

--- a/src/constants-and-lookups.js
+++ b/src/constants-and-lookups.js
@@ -15,7 +15,8 @@ const googleDimensions = Object.assign({
   'ga:eventAction': 'eventAction',
   'ga:eventLabel': 'eventLabel',
   'ga:country': 'country',
-  'ga:countryIsoCode': 'countryIsoCode'
+  'ga:countryIsoCode': 'countryIsoCode',
+  'ga:hostname': 'hostname'
 }, customNonTimeDimensions)
 
 const googleMetrics = Object.assign({


### PR DESCRIPTION
This PR:

* Adds `hostname` to dimension map.  This is critical because if the `:dimension` URL parameter or  `where` query parameter includes a `hostname`, this needs to be translated to `ga:hostname` before sending it as a dimension parameter to Google Analytics API.  (It might make sense to make some middleware that assumes all that needs to be done is to append `ga:` to any requested metric/dimension or `where` item. Will save that for a separate PR in order to expedite support for `hostname`)

* Adds support for gh-release

* Fixes broken links in package.json