### PR TITLE
Allow backfilling of empty rows on multi-dimension requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Backfill option that adds empty rows when multiply dimensions are requested
+
 ## [1.2.2] - 2019-02-25
 ### Fixed
 * Bumped version due to need to republish npm

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This provider ships with a sample instance `server.js` which registers koop-prov
 #### Config file
 If you prefer, you can set the required variables in the Koop configuration file rather than as environment variables.  See [config/default.js.example](config/default.js.example) for specifics.  The configuration file can also be use to customize the provider's support for additional Google Analytics dimensions and metrics. The [config/default.js.example](config/default.js.example) includes examples of adding dimensions and metrics not already defined in [src/constants-and-lookups.js](src/constants-and-lookups.js).  You will need to remove `.example` from the filename in order for the `config` npm to read and register this file.
 
+#### Backfill multi-dimesional time-series data
+The Google Analytics API won't include empty rows when requesting multiple dimensions; if you want empty rows for a request with a time dimension plus at least one other dimension, set the `backfillTimeseries` configuration setting to `true`.
+
 With the above environment variables and or config set, the Koop server can be started with:
 ```
   node server.js

--- a/config/default.js.example
+++ b/config/default.js.example
@@ -13,7 +13,8 @@ config.goog = Object.freeze({
   },
   metrics: {
     'ga:newUsers': 'newUsers'
-  }
+  },
+  backfillTimeseries: true
 })
 
 // The analytics cache setting

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "joi": "^13.4.0",
     "koop": "^3.9.0",
     "lodash": "^4.17.10",
-    "moment": "^2.22.2",
-    "moment-range": "^4.0.1",
+    "moment": "^2.24.0",
+    "moment-range": "^4.0.2",
     "moment-timezone": "^0.5.21",
     "object-hash": "^1.3.0"
   },

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const path = require('path')
 process.env.NODE_CONFIG_DIR = process.env.NODE_CONFIG_DIR || path.join(__dirname, 'config')
 process.env.NODE_CONFIG_ENV = 'index'
 
-  // Initialize Koop
+// Initialize Koop
 const Koop = require('koop')
 const koop = new Koop()
 

--- a/src/backfill-timeseries-features.js
+++ b/src/backfill-timeseries-features.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
-const Moment = require('moment');
-const MomentRange = require('moment-range');
-const moment = MomentRange.extendMoment(Moment);
+const Moment = require('moment')
+const MomentRange = require('moment-range')
+const moment = MomentRange.extendMoment(Moment)
 const { timeDimensionToTimestamp } = require('./time')
 
 function backfillTimeseriesFeatures ({ startDate, endDate, interval, timezone, geojson }) {
@@ -13,15 +13,15 @@ function backfillTimeseriesFeatures ({ startDate, endDate, interval, timezone, g
   return _.chain(features).concat(missingTimestamps).orderBy('properties.timestamp').value()
 }
 
-function timeSeriesRange({ startDate, endDate, interval, timezone }) {
-  const range = moment.range(startDate, endDate);
+function timeSeriesRange ({ startDate, endDate, interval, timezone }) {
+  const range = moment.range(startDate, endDate)
   return Array.from(range.by(interval)).map(date => {
-    return { 
+    return {
       type: 'Feature',
       properties: { timestamp: timeDimensionToTimestamp(interval, date, timezone) },
       geometry: null
     }
-  });
+  })
 }
 
 module.exports = backfillTimeseriesFeatures

--- a/src/backfill-timeseries-features.js
+++ b/src/backfill-timeseries-features.js
@@ -1,0 +1,27 @@
+const _ = require('lodash')
+const Moment = require('moment');
+const MomentRange = require('moment-range');
+const moment = MomentRange.extendMoment(Moment);
+const { timeDimensionToTimestamp } = require('./time')
+
+function backfillTimeseriesFeatures ({ startDate, endDate, interval, timezone, geojson }) {
+  const features = _.chain(geojson.features).cloneDeep().value()
+  const range = timeSeriesRange({ startDate, endDate, interval, timezone })
+  const missingTimestamps = _.differenceWith(range, features, (backfill, feature) => {
+    return backfill.properties.timestamp === feature.properties.timestamp
+  })
+  return _.chain(features).concat(missingTimestamps).orderBy('properties.timestamp').value()
+}
+
+function timeSeriesRange({ startDate, endDate, interval, timezone }) {
+  const range = moment.range(startDate, endDate);
+  return Array.from(range.by(interval)).map(date => {
+    return { 
+      type: 'Feature',
+      properties: { timestamp: timeDimensionToTimestamp(interval, date, timezone) },
+      geometry: null
+    }
+  });
+}
+
+module.exports = backfillTimeseriesFeatures

--- a/src/constants-and-lookups.js
+++ b/src/constants-and-lookups.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const config = require('config')
-const customNonTimeDimensions = _.get(config, `goog.dimensions`) || {}
-const customMetrics = _.get(config, `goog.metrics`) || {}
+const customNonTimeDimensions = _.get(config, 'goog.dimensions') || {}
+const customMetrics = _.get(config, 'goog.metrics') || {}
 
 const googleTimeDimensions = {
   'ga:dateHour': 'hour',

--- a/src/model.js
+++ b/src/model.js
@@ -4,7 +4,7 @@
   Documentation: http://koopjs.github.io/docs/specs/provider/
 */
 const { google } = require('googleapis')
-const analytics = google.analyticsreporting({version: 'v4'})
+const analytics = google.analyticsreporting({ version: 'v4' })
 const hash = require('object-hash')
 const _ = require('lodash')
 const {
@@ -72,7 +72,7 @@ Model.prototype.getData = function (req, callback) {
       geojson.metadata = {
         name: `${params.value.metric.join(', ')} by ${params.value.dimension.join(', ')}`,
         title: `${params.value.metric.join(', ')} by ${params.value.dimension.join(', ')}`,
-        description: `This provider converts Koop request parameters to parameters required by Google Analytics, and translates the response to GeoJSON for use in Koop output services`,
+        description: 'This provider converts Koop request parameters to parameters required by Google Analytics, and translates the response to GeoJSON for use in Koop output services',
         maxRecordCount: MAX_RECORD_COUNT
       }
 
@@ -100,7 +100,7 @@ Model.prototype.getData = function (req, callback) {
  * @param {*} req
  */
 Model.prototype.createKey = function (req) {
-  let validatedParams = validateParams(req)
+  const validatedParams = validateParams(req)
   if (!validatedParams.error) {
     return `${req.url.split('/')[1]}::${hash(validatedParams.value)}`
   }
@@ -128,13 +128,13 @@ function prepareRequestBody (params) {
 
   // Create the google analytics request parameters
   return {
-    'auth': jwt,
+    auth: jwt,
     resource: {
       reportRequests: [{
         viewId: `ga:${googViewId}`,
         pageSize: MAX_RECORD_COUNT,
-        dateRanges: [ {startDate: params.time.startDate, endDate: params.time.endDate} ],
-        metrics: params.metric.map(m => { return {expression: providerParamToGoogle[m]} }),
+        dateRanges: [{ startDate: params.time.startDate, endDate: params.time.endDate }],
+        metrics: params.metric.map(m => { return { expression: providerParamToGoogle[m] } }),
         dimensions: params.dimension.map(d => { return { name: providerParamToGoogle[d] } }),
         metricFilterClauses: [{ operator: params.where.metricFilters.operator, filters: params.where.metricFilters.filters.map(transformMetricPredicate) }],
         dimensionFilterClauses: [{ operator: params.where.dimensionFilters.operator, filters: params.where.dimensionFilters.filters.map(transformDimensionPredicate) }],
@@ -164,7 +164,7 @@ function translate (metadata, data) {
   })
 
   // Map data rows to geojson features
-  const features = data.map(row => { return formatFeature(row, {dimensions: dimensionMetadata, metrics: metricsMetadata}) })
+  const features = data.map(row => { return formatFeature(row, { dimensions: dimensionMetadata, metrics: metricsMetadata }) })
 
   // Return the GeoJSON feature collection
   return {
@@ -199,8 +199,8 @@ function formatFeature (input, metadata) {
   })
 
   // Support geometry for country dimensioning.  If the properties include countryIsoCode, we can use it to pull geometry from a country.json file
-  if (properties.hasOwnProperty('countryIsoCode')) {
-    let country = _.find(countries.features, ['properties.ISO_A2', properties.countryIsoCode]) || {}
+  if (properties['countryIsoCode']) {
+    const country = _.find(countries.features, ['properties.ISO_A2', properties.countryIsoCode]) || {}
     geometry = country.geometry
   }
 
@@ -210,8 +210,6 @@ function formatFeature (input, metadata) {
     geometry
   }
 }
-
-
 
 function shouldBackfill (dimensions) {
   return backfillTimeseries && dimensions.length > 1 && getTimeDimension(dimensions)

--- a/src/param-validation.js
+++ b/src/param-validation.js
@@ -75,7 +75,7 @@ function timeArray (joi) {
       // Validate a two element array with either null, a timestamp, or a YYYY-MM-DD string
       if (timerange.length !== 2 || timerange.some(time => {
         if (time !== 'null' && !moment(Number(time)).isValid() && !moment(time, 'YYYY-MM-DD').isValid()) return true
-      })) return this.createError(`"time" param must be a comma delimited string: "<start>,<end>". Use "null", a YYY-MM-DD string, or a unix timestamp`, { v: value }, state, options)
+      })) return this.createError('"time" param must be a comma delimited string: "<start>,<end>". Use "null", a YYY-MM-DD string, or a unix timestamp', { v: value }, state, options)
 
       // Handle nulls
       if (timerange[0] === 'null') startDate = dateRangeStart
@@ -100,7 +100,7 @@ function outFields (joi) {
     name: 'outFields',
     coerce (value, state, options) {
       if (!value) return
-      if (typeof value !== 'string') return this.createError(`"outFields" param should be a string`, { v: value }, state, options)
+      if (typeof value !== 'string') return this.createError('"outFields" param should be a string', { v: value }, state, options)
       if (value === '*') return []
       return value.split(',')
     }
@@ -112,11 +112,11 @@ const customJoi = Joi.extend(doubleColonDelimited).extend(where).extend(outField
 
 // Create a validation and default value schema for incoming request parameters
 const paramsSchema = Joi.object().keys({
-  'dimension': customJoi.doubleColonDelimited().dimensions().items(DIMENSIONS).single().error(new CodedError(`Invalid "dimensions" parameter`, 400)),
-  'metric': customJoi.doubleColonDelimited().items(METRICS).single().error(new CodedError(`"metric" parameter must be one of: ${METRICS.join(', ')}`, 400)),
-  'where': customJoi.where().default({ metricFilters: { filters: [] }, dimensionFilters: { filters: [] } }).error((errors) => { return new CodedError(errors[0].message || errors[0].type, 400) }),
-  'outFields': customJoi.outFields().default([]).error((errors) => { return new CodedError(errors[0].message || errors[0].type, 400) }),
-  'time': customJoi.timeArray().default(function () { return { startDate: dateRangeStart, endDate: moment().format('YYYY-MM-DD') } }, 'time')
+  dimension: customJoi.doubleColonDelimited().dimensions().items(DIMENSIONS).single().error(new CodedError('Invalid "dimensions" parameter', 400)),
+  metric: customJoi.doubleColonDelimited().items(METRICS).single().error(new CodedError(`"metric" parameter must be one of: ${METRICS.join(', ')}`, 400)),
+  where: customJoi.where().default({ metricFilters: { filters: [] }, dimensionFilters: { filters: [] } }).error((errors) => { return new CodedError(errors[0].message || errors[0].type, 400) }),
+  outFields: customJoi.outFields().default([]).error((errors) => { return new CodedError(errors[0].message || errors[0].type, 400) }),
+  time: customJoi.timeArray().default(function () { return { startDate: dateRangeStart, endDate: moment().format('YYYY-MM-DD') } }, 'time')
 }).unknown()
 
 /**

--- a/src/where.js
+++ b/src/where.js
@@ -63,7 +63,7 @@ function enrichAST (node) {
       return result
     }
 
-    result.predicates = [{key: column, value, operator: node.operator, type: _.get(result, 'types[0]')}]
+    result.predicates = [{ key: column, value, operator: node.operator, type: _.get(result, 'types[0]') }]
     return result
   }
 
@@ -109,7 +109,7 @@ function validateTranslatable (enrichedAST) {
       if (enrichedAST.logicalOperators[0] === 'OR') enrichedAST.error = new CodedError('Metric and dimension predicates cannot be combined with OR, only with AND.', 400)
 
       // Sets of metrics predicates need to be partioned in left and right parenthesis at the top level of the AST.
-      else if (enrichedAST.left.types.length > 1 || enrichedAST.right.types.length > 1) enrichedAST.error = new CodedError(`Metric and dimension predicates should be partioned into left and right collections with parenthesis, e.g. (views > 50 OR session > 20) AND (itemId='abcd123' OR country='United States')`, 400)
+      else if (enrichedAST.left.types.length > 1 || enrichedAST.right.types.length > 1) enrichedAST.error = new CodedError('Metric and dimension predicates should be partioned into left and right collections with parenthesis, e.g. (views > 50 OR session > 20) AND (itemId=\'abcd123\' OR country=\'United States\')', 400)
       // Predicates within a partitioned set can only be combined with one type of logical operator (AND or OR, not both)
       else if (_.size(enrichedAST.left.logicalOperators) > 1 || _.size(enrichedAST.right.logicalOperators) > 1) enrichedAST.error = new CodedError('Mixed logical operators (AND, OR) within sets of metric or dimension predicates are not supported', 400)
     }
@@ -125,8 +125,8 @@ function validateTranslatable (enrichedAST) {
 function translate (enrichedAST) {
   // If error, exit
   if (enrichedAST.error) return enrichedAST
-  let metricFilters = {}
-  let dimensionFilters = {}
+  const metricFilters = {}
+  const dimensionFilters = {}
 
   // Organize predicates by type
   metricFilters.filters = enrichedAST.predicates.filter(p => p.type === 'metric')

--- a/test/backfill-timeseries-features-test.js
+++ b/test/backfill-timeseries-features-test.js
@@ -1,0 +1,65 @@
+const test = require('tape')
+const backfillTimeseriesFeatures = require('../src/backfill-timeseries-features')
+
+test('backfillTimeseriesFeatures - by day', spec => {
+  spec.plan(3)
+  const startDate ='2020-01-01'
+  const endDate = '2020-01-31'
+  const interval = 'day'
+  const timezone = 'America/New_York'
+  const geojson = {
+    features: [
+      {
+        properties: {
+          timestamp: '2020-01-23T23:59:59.999-0400'
+        }
+      }
+    ]
+  }
+  const backfilled = backfillTimeseriesFeatures({ startDate, endDate, interval, timezone, geojson })
+  spec.equals(backfilled.length, 32)
+  spec.isEquivalent(backfilled[0], { type: 'Feature', properties: { timestamp: '2020-01-01T23:59:59.999-0500' }, geometry: null })
+  spec.isEquivalent(backfilled[31], { type: 'Feature', properties: { timestamp: '2020-01-31T23:59:59.999-0500' }, geometry: null })
+})
+
+test('backfillTimeseriesFeatures - by hour', spec => {
+  spec.plan(3)
+  const startDate ='2020-01-01'
+  const endDate = '2020-01-31'
+  const interval = 'hour'
+  const timezone = 'America/New_York'
+  const geojson = {
+    features: [
+      {
+        properties: {
+          timestamp: '2020-01-23T23:59:59.999-0400'
+        }
+      }
+    ]
+  }
+  const backfilled = backfillTimeseriesFeatures({ startDate, endDate, interval, timezone, geojson })
+  spec.equals(backfilled.length, 722)
+  spec.isEquivalent(backfilled[0], { type: 'Feature', properties: { timestamp: '2020-01-01T00:59:59.999-0500' }, geometry: null })
+  spec.isEquivalent(backfilled[721], { type: 'Feature', properties: { timestamp: '2020-01-31T00:59:59.999-0500' }, geometry: null })
+})
+
+test('backfillTimeseriesFeatures - by hour', spec => {
+  spec.plan(3)
+  const startDate ='2020-01-01'
+  const endDate = '2020-01-31'
+  const interval = 'month'
+  const timezone = 'America/New_York'
+  const geojson = {
+    features: [
+      {
+        properties: {
+          timestamp: '2020-01-23T23:59:59.999-0400'
+        }
+      }
+    ]
+  }
+  const backfilled = backfillTimeseriesFeatures({ startDate, endDate, interval, timezone, geojson })
+  spec.equals(backfilled.length, 2)
+  spec.isEquivalent(backfilled[0], { properties: { timestamp: '2020-01-23T23:59:59.999-0400' } })
+  spec.isEquivalent(backfilled[1], { type: 'Feature', properties: { timestamp: '2020-01-31T23:59:59.999-0500' }, geometry: null })
+})

--- a/test/backfill-timeseries-features-test.js
+++ b/test/backfill-timeseries-features-test.js
@@ -3,7 +3,7 @@ const backfillTimeseriesFeatures = require('../src/backfill-timeseries-features'
 
 test('backfillTimeseriesFeatures - by day', spec => {
   spec.plan(3)
-  const startDate ='2020-01-01'
+  const startDate = '2020-01-01'
   const endDate = '2020-01-31'
   const interval = 'day'
   const timezone = 'America/New_York'
@@ -24,7 +24,7 @@ test('backfillTimeseriesFeatures - by day', spec => {
 
 test('backfillTimeseriesFeatures - by hour', spec => {
   spec.plan(3)
-  const startDate ='2020-01-01'
+  const startDate = '2020-01-01'
   const endDate = '2020-01-31'
   const interval = 'hour'
   const timezone = 'America/New_York'
@@ -45,7 +45,7 @@ test('backfillTimeseriesFeatures - by hour', spec => {
 
 test('backfillTimeseriesFeatures - by hour', spec => {
   spec.plan(3)
-  const startDate ='2020-01-01'
+  const startDate = '2020-01-01'
   const endDate = '2020-01-31'
   const interval = 'month'
   const timezone = 'America/New_York'

--- a/test/fixtures/multi-dimension.json
+++ b/test/fixtures/multi-dimension.json
@@ -1,0 +1,217 @@
+{
+  "data": {
+    "reports": [
+      {
+        "columnHeader": {
+          "dimensions": [
+            "ga:date",
+            "ga:eventCategory"
+          ],
+          "metricHeader": {
+            "metricHeaderEntries": [
+              {
+                "name": "ga:pageviews",
+                "type": "INTEGER"
+              }
+            ]
+          }
+        },
+        "data": {
+          "rows": [
+            {
+              "dimensions": [
+                "20200323",
+                "anonymous"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "1"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200323",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "3"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200324",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "5"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200325",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "4"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200326",
+                "anonymous"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "4"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200326",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "3"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200327",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "1"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200329",
+                "anonymous"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "4"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200403",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "6"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200406",
+                "anonymous"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "2"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200407",
+                "anonymous"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "1"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200407",
+                "staff"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "2"
+                  ]
+                }
+              ]
+            },
+            {
+              "dimensions": [
+                "20200410",
+                "anonymous"
+              ],
+              "metrics": [
+                {
+                  "values": [
+                    "3"
+                  ]
+                }
+              ]
+            }
+          ],
+          "totals": [
+            {
+              "values": [
+                "39"
+              ]
+            }
+          ],
+          "rowCount": 13,
+          "minimums": [
+            {
+              "values": [
+                "1"
+              ]
+            }
+          ],
+          "maximums": [
+            {
+              "values": [
+                "6"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -11,13 +11,12 @@ const manyMetricsManyDimensFixture = require('./fixtures/many-metrics-many-dimen
 const sumFixture = require('./fixtures/sum')
 const multiDimensionFixture = require('./fixtures/multi-dimension')
 const proxyquire = require('proxyquire')
-const _ = require('lodash')
 
 test('should properly translate features from Google Analystics API response to GeoJSON - 30 day time-series', t => {
   t.plan(11)
-  const Model = proxyquire('../src/model', { 'googleapis': getGoogleApiMock(dailyTimeSeriesFixture) })
+  const Model = proxyquire('../src/model', { googleapis: getGoogleApiMock(dailyTimeSeriesFixture) })
   const model = new Model()
-  model.getData({params: {host: 'views', id: 'day'}, query: {time: '2018-06-20,2018-07-20'}}, (err, geojson) => {
+  model.getData({ params: { host: 'views', id: 'day' }, query: { time: '2018-06-20,2018-07-20' } }, (err, geojson) => {
     t.notOk(err)
     t.equal(geojson.type, 'FeatureCollection')
     t.ok(geojson.features)
@@ -34,9 +33,9 @@ test('should properly translate features from Google Analystics API response to 
 
 test('should properly translate features from Google Analystics API response to GeoJSON - 30 day sum', t => {
   t.plan(2)
-  const Model = proxyquire('../src/model', { 'googleapis': getGoogleApiMock(sumFixture) })
+  const Model = proxyquire('../src/model', { googleapis: getGoogleApiMock(sumFixture) })
   const model = new Model()
-  model.getData({params: {host: 'views', id: 'none'}, query: {time: '2018-06-20,2018-07-20'}}, (err, geojson) => {
+  model.getData({ params: { host: 'views', id: 'none' }, query: { time: '2018-06-20,2018-07-20' } }, (err, geojson) => {
     t.equal(err, null)
     t.equal(geojson.features[0].properties.views, 27179)
   })
@@ -44,7 +43,7 @@ test('should properly translate features from Google Analystics API response to 
 
 test('should properly handle and translate concatenated metrics and dimension parameters', t => {
   t.plan(7)
-  const Model = proxyquire('../src/model', { 'googleapis': getGoogleApiMock(manyMetricsManyDimensFixture) })
+  const Model = proxyquire('../src/model', { googleapis: getGoogleApiMock(manyMetricsManyDimensFixture) })
   const model = new Model()
   model.getData({ params: { host: 'sessions::views', id: 'country::month', method: 'query' }, query: {} }, (err, geojson) => {
     t.equal(err, null)
@@ -59,9 +58,9 @@ test('should properly handle and translate concatenated metrics and dimension pa
 
 test('should properly modify outFields parameter when a where clause with extra dimensions is added', t => {
   t.plan(2)
-  const Model = proxyquire('../src/model', { 'googleapis': getGoogleApiMock(manyMetricsManyDimensFixture) })
+  const Model = proxyquire('../src/model', { googleapis: getGoogleApiMock(manyMetricsManyDimensFixture) })
   const model = new Model()
-  const req = {params: {host: 'sessions::views', id: 'month'}, query: { where: `country='Canada'` }}
+  const req = { params: { host: 'sessions::views', id: 'month' }, query: { where: 'country=\'Canada\'' } }
   model.getData(req, (err, geojson) => {
     t.equal(err, null)
     t.equal(req.query.outFields, 'sessions,views,month,timestamp,OBJECTID')
@@ -71,8 +70,8 @@ test('should properly modify outFields parameter when a where clause with extra 
 test('should properly backfill features from Google Analystics API response', t => {
   t.plan(2)
   const Model = proxyquire('../src/model', {
-    'googleapis': getGoogleApiMock(multiDimensionFixture),
-    'config': {
+    googleapis: getGoogleApiMock(multiDimensionFixture),
+    config: {
       goog: {
         backfillTimeseries: true,
         analyticsTimezone: 'America/New_York'
@@ -80,7 +79,7 @@ test('should properly backfill features from Google Analystics API response', t 
     }
   })
   const model = new Model()
-  model.getData({params: {host: 'views', id: 'day::eventCategory'}, query: {time: '2020-03-20,2020-04-20'}}, (err, geojson) => {
+  model.getData({ params: { host: 'views', id: 'day::eventCategory' }, query: { time: '2020-03-20,2020-04-20' } }, (err, geojson) => {
     t.notOk(err)
     t.equals(geojson.features.length, 35)
   })
@@ -88,13 +87,13 @@ test('should properly backfill features from Google Analystics API response', t 
 
 test('should reject with 400 error do to bad request parameters', t => {
   t.plan(4)
-  const Model = proxyquire('../src/model', { 'googleapis': getGoogleApiMock(dailyTimeSeriesFixture) })
+  const Model = proxyquire('../src/model', { googleapis: getGoogleApiMock(dailyTimeSeriesFixture) })
   const model = new Model()
-  model.getData({params: {host: 'bad-param', id: 'day'}, query: {}}, (err, geojson) => {
+  model.getData({ params: { host: 'bad-param', id: 'day' }, query: {} }, (err, geojson) => {
     t.ok(err)
     t.equal(err.code, 400)
   })
-  model.getData({params: {host: 'views', id: 'bad-param'}, query: {}}, (err, geojson) => {
+  model.getData({ params: { host: 'views', id: 'bad-param' }, query: {} }, (err, geojson) => {
     t.ok(err)
     t.equal(err.code, 400)
   })
@@ -109,13 +108,13 @@ function getGoogleApiMock (data) {
             // The main get data from Google function
             batchGet: async function (params) {
               // Needs to return a promise
-                return Promise.resolve(data)
+              return Promise.resolve(data)
             }
           }
         }
       },
       // JWT function
-      auth: {JWT: function () { return '' }}
+      auth: { JWT: function () { return '' } }
     }
   }
 }

--- a/test/param-validation-test.js
+++ b/test/param-validation-test.js
@@ -3,7 +3,7 @@ const _ = require('lodash')
 const validateParams = require('../src/param-validation')
 
 test('validateParams - simple metric and dimension params', function (t) {
-  let req = { params: { host: 'views', id: 'country' }, query: {} }
+  const req = { params: { host: 'views', id: 'country' }, query: {} }
   const result = validateParams(req)
   t.plan(5)
   t.equals(result.error, null)
@@ -14,7 +14,7 @@ test('validateParams - simple metric and dimension params', function (t) {
 })
 
 test('validateParams - time params, unix', function (t) {
-  let req = { params: { host: 'views', id: 'country' }, query: {time: '0,' + 86400000} }
+  const req = { params: { host: 'views', id: 'country' }, query: { time: '0,' + 86400000 } }
   const result = validateParams(req)
   t.plan(6)
   t.equals(result.error, null)
@@ -26,7 +26,7 @@ test('validateParams - time params, unix', function (t) {
 })
 
 test('validateParams - time params, YYYY-MM-DD', function (t) {
-  let req = { params: { host: 'views', id: 'country' }, query: {time: '2017-01-01,2017-06-30'} }
+  const req = { params: { host: 'views', id: 'country' }, query: { time: '2017-01-01,2017-06-30' } }
   const result = validateParams(req)
   t.plan(6)
   t.equals(result.error, null)
@@ -38,7 +38,7 @@ test('validateParams - time params, YYYY-MM-DD', function (t) {
 })
 
 test('validateParams - compound metric and dimension params', function (t) {
-  let req = { params: { host: 'views::sessions', id: 'country::month' }, query: {} }
+  const req = { params: { host: 'views::sessions', id: 'country::month' }, query: {} }
   const result = validateParams(req)
   t.plan(6)
   t.equals(result.error, null)
@@ -50,7 +50,7 @@ test('validateParams - compound metric and dimension params', function (t) {
 })
 
 test('validateParams - "none" dimension', function (t) {
-  let req = { params: { host: 'views', id: 'none' }, query: {} }
+  const req = { params: { host: 'views', id: 'none' }, query: {} }
   const result = validateParams(req)
   t.plan(3)
   t.equals(result.error, null)
@@ -59,7 +59,7 @@ test('validateParams - "none" dimension', function (t) {
 })
 
 test('validateParams - compound dimension with "none"', function (t) {
-  let req = { params: { host: 'views', id: 'none::month' }, query: {} }
+  const req = { params: { host: 'views', id: 'none::month' }, query: {} }
   const result = validateParams(req)
   t.plan(4)
   t.equals(result.error, null)
@@ -69,7 +69,7 @@ test('validateParams - compound dimension with "none"', function (t) {
 })
 
 test('validateParams - where', function (t) {
-  let req = {params: {host: 'views', id: 'country'}, query: {where: `(country='Canada' OR 'United States'=country) ANd views > 1000`}}
+  const req = { params: { host: 'views', id: 'country' }, query: { where: '(country=\'Canada\' OR \'United States\'=country) ANd views > 1000' } }
   const result = validateParams(req)
   t.plan(10)
   t.equals(result.error, null)
@@ -85,7 +85,7 @@ test('validateParams - where', function (t) {
 })
 
 test('validateParams - where with 1=1', function (t) {
-  let req = {params: {host: 'views', id: 'country'}, query: {where: `1=1`}}
+  const req = { params: { host: 'views', id: 'country' }, query: { where: '1=1' } }
   const result = validateParams(req)
   t.plan(3)
   t.equals(result.error, null)
@@ -94,7 +94,7 @@ test('validateParams - where with 1=1', function (t) {
 })
 
 test('validateParams - where with 1=1 AND views > 100', function (t) {
-  let req = {params: {host: 'views', id: 'country'}, query: {where: `1=1 AND views > 100`}}
+  const req = { params: { host: 'views', id: 'country' }, query: { where: '1=1 AND views > 100' } }
   const result = validateParams(req)
   t.plan(3)
   t.equals(result.error, null)
@@ -103,7 +103,7 @@ test('validateParams - where with 1=1 AND views > 100', function (t) {
 })
 
 test('validateParams - where with views > 100 AND (1=1)', function (t) {
-  let req = {params: {host: 'views', id: 'country'}, query: {where: `views > 100 AND (1=1)`}}
+  const req = { params: { host: 'views', id: 'country' }, query: { where: 'views > 100 AND (1=1)' } }
   const result = validateParams(req)
   t.plan(3)
   t.equals(result.error, null)
@@ -112,7 +112,7 @@ test('validateParams - where with views > 100 AND (1=1)', function (t) {
 })
 
 test('validateParams - where syntax error', function (t) {
-  let req = {params: {host: 'views', id: 'country'}, query: {where: `(country="Canada" OR 'United States'=country ANd views > 1000`}}
+  const req = { params: { host: 'views', id: 'country' }, query: { where: '(country="Canada" OR \'United States\'=country ANd views > 1000' } }
   const result = validateParams(req)
   t.plan(2)
   t.equals(result.error !== null, true)

--- a/test/where-test.js
+++ b/test/where-test.js
@@ -3,7 +3,7 @@ const { whereDecomposer } = require('../src/where')
 
 test('whereDecomposer - single metric predicate', t => {
   t.plan(6)
-  let result = whereDecomposer(`views = 100`)
+  const result = whereDecomposer('views = 100')
   t.notOk(result.error)
   t.equals(result.metricFilters.filters.length, 1)
   t.equals(result.dimensionFilters.filters.length, 0)
@@ -14,7 +14,7 @@ test('whereDecomposer - single metric predicate', t => {
 
 test('whereDecomposer - single dimension predicate', t => {
   t.plan(6)
-  let result = whereDecomposer(`country = 'United States'`)
+  const result = whereDecomposer('country = \'United States\'')
   t.notOk(result.error)
   t.equals(result.dimensionFilters.filters.length, 1)
   t.equals(result.metricFilters.filters.length, 0)
@@ -25,7 +25,7 @@ test('whereDecomposer - single dimension predicate', t => {
 
 test('whereDecomposer - single dimension predicate, trailing column', t => {
   t.plan(6)
-  let result = whereDecomposer(`'United States'=country`)
+  const result = whereDecomposer('\'United States\'=country')
   t.notOk(result.error)
   t.equals(result.dimensionFilters.filters.length, 1)
   t.equals(result.metricFilters.filters.length, 0)
@@ -36,7 +36,7 @@ test('whereDecomposer - single dimension predicate, trailing column', t => {
 
 test('whereDecomposer - multiple (metric) predicates combined with AND', t => {
   t.plan(10)
-  let result = whereDecomposer(`views = 100 AND sessions = 10`)
+  const result = whereDecomposer('views = 100 AND sessions = 10')
   t.notOk(result.error)
   t.equals(result.metricFilters.filters.length, 2)
   t.equals(result.dimensionFilters.filters.length, 0)
@@ -51,7 +51,7 @@ test('whereDecomposer - multiple (metric) predicates combined with AND', t => {
 
 test('whereDecomposer - multiple (metric) predicates combined with OR', t => {
   t.plan(10)
-  let result = whereDecomposer(`views = 100 OR sessions = 10`)
+  const result = whereDecomposer('views = 100 OR sessions = 10')
   t.notOk(result.error)
   t.equals(result.metricFilters.filters.length, 2)
   t.equals(result.dimensionFilters.filters.length, 0)
@@ -66,7 +66,7 @@ test('whereDecomposer - multiple (metric) predicates combined with OR', t => {
 
 test('whereDecomposer - multiple (metric and dimension) predicates combined with AND', t => {
   t.plan(9)
-  let result = whereDecomposer(`views = 100 AND country = 'United States'`)
+  const result = whereDecomposer('views = 100 AND country = \'United States\'')
   t.notOk(result.error)
   t.equals(result.metricFilters.filters.length, 1)
   t.equals(result.dimensionFilters.filters.length, 1)
@@ -80,7 +80,7 @@ test('whereDecomposer - multiple (metric and dimension) predicates combined with
 
 test('whereDecomposer - multiple metric and dimension predicates', t => {
   t.plan(17)
-  let result = whereDecomposer(`(views = 100 AND sessions = 10) AND (country = 'United States' OR country = 'Canada')`)
+  const result = whereDecomposer('(views = 100 AND sessions = 10) AND (country = \'United States\' OR country = \'Canada\')')
   t.notOk(result.error)
   t.equals(result.metricFilters.filters.length, 2)
   t.equals(result.dimensionFilters.filters.length, 2)
@@ -102,36 +102,36 @@ test('whereDecomposer - multiple metric and dimension predicates', t => {
 
 test('whereDecomposer - fail with invalid SQL', t => {
   t.plan(1)
-  let result = whereDecomposer(`views = 100 country = 'United States'`)
+  const result = whereDecomposer('views = 100 country = \'United States\'')
   t.ok(result.error)
 })
 
 test('whereDecomposer - fail with unsupported key name', t => {
   t.plan(1)
-  let result = whereDecomposer(`iews = 100`)
+  const result = whereDecomposer('iews = 100')
   t.ok(result.error)
 })
 
 test('whereDecomposer - fail with unsupported operator', t => {
   t.plan(1)
-  let result = whereDecomposer(`itemId IN ('01', '03')`)
+  const result = whereDecomposer('itemId IN (\'01\', \'03\')')
   t.ok(result.error)
 })
 
 test('whereDecomposer - fail when combining metric and dimensions with OR', t => {
   t.plan(1)
-  let result = whereDecomposer(`views = 100 OR country = 'United States'`)
+  const result = whereDecomposer('views = 100 OR country = \'United States\'')
   t.ok(result.error)
 })
 
 test('whereDecomposer - fail when combining metrics with multiple logical operators', t => {
   t.plan(1)
-  let result = whereDecomposer(`views = 100 OR views = 1000 AND sessions = 10`)
+  const result = whereDecomposer('views = 100 OR views = 1000 AND sessions = 10')
   t.ok(result.error)
 })
 
 test('whereDecomposer - fail when combining metrics with multiple logical operators', t => {
   t.plan(1)
-  let result = whereDecomposer(`(views = 100 OR views = 1000 AND sessions = 10) AND (country = 'United States')`)
+  const result = whereDecomposer('(views = 100 OR views = 1000 AND sessions = 10) AND (country = \'United States\')')
   t.ok(result.error)
 })


### PR DESCRIPTION
Google Analytics ignores `includeEmptyRows` when more than one dimension is requested.  Here we add empty rows for those types of requests.